### PR TITLE
feat(homepage): apply i18n translations and disable unused sections

### DIFF
--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -33,4 +33,29 @@ test.describe('Dark mode', () => {
   test('light mode can be activated via color scheme emulation', async ({page}) => {
     await emulateAndVerifyTheme(page, 'light');
   });
+
+  test('does not render the bright hero fallback image while the hero SVG is still loading', async ({page}) => {
+    await page.emulateMedia({colorScheme: 'dark'});
+
+    let releaseSvgRequest: (() => void) | undefined;
+    const holdSvgRequest = new Promise<void>(resolve => {
+      releaseSvgRequest = resolve;
+    });
+
+    await page.route('**/images/home/hero-illustration.svg', async route => {
+      await holdSvgRequest;
+      await route.continue();
+    });
+
+    await page.goto('/', {waitUntil: 'domcontentloaded'});
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await expect(page.locator('.hero-text-section')).toBeVisible();
+    await page.waitForTimeout(500);
+
+    const fallbackImage = page.locator('img.hero-illustration-svg[src*="hero-illustration.png"]');
+    await expect(fallbackImage).toHaveCount(0);
+
+    releaseSvgRequest?.();
+    await page.waitForLoadState('networkidle');
+  });
 });

--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -37,12 +37,20 @@ test.describe('Dark mode', () => {
   test('does not render the bright hero fallback image while the hero SVG is still loading', async ({page}) => {
     await page.emulateMedia({colorScheme: 'dark'});
 
-    let releaseSvgRequest: (() => void) | undefined;
+    let releaseSvgRequest!: () => void;
+    let resolveSvgRequestStarted!: () => void;
     const holdSvgRequest = new Promise<void>(resolve => {
       releaseSvgRequest = resolve;
     });
+    const svgRequestStarted = new Promise<void>(resolve => {
+      resolveSvgRequestStarted = resolve;
+    });
+    const svgResponse = page.waitForResponse(response =>
+      response.url().includes('/images/home/hero-illustration.svg'),
+    );
 
     await page.route('**/images/home/hero-illustration.svg', async route => {
+      resolveSvgRequestStarted();
       await holdSvgRequest;
       await route.continue();
     });
@@ -50,12 +58,12 @@ test.describe('Dark mode', () => {
     await page.goto('/', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
     await expect(page.locator('.hero-text-section')).toBeVisible();
-    await page.waitForTimeout(500);
+    await svgRequestStarted;
 
     const fallbackImage = page.locator('img.hero-illustration-svg[src*="hero-illustration.png"]');
     await expect(fallbackImage).toHaveCount(0);
 
-    releaseSvgRequest?.();
-    await page.waitForLoadState('networkidle');
+    releaseSvgRequest();
+    await svgResponse;
   });
 });

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -573,6 +573,226 @@
     "message": "Laravel - The PHP Framework for Web Artisans",
     "description": "The image alt text for the homepage"
   },
+  "homepage.cta.title.part1": {
+    "message": "Create without limits.",
+    "description": "CTA 제목 앞"
+  },
+  "homepage.cta.title.part2": {
+    "message": "What will you ship?",
+    "description": "CTA 제목 뒤"
+  },
+  "homepage.cta.deploy": {
+    "message": "Deploy on Cloud",
+    "description": "CTA - 클라우드 배포 버튼"
+  },
+  "homepage.cta.docs": {
+    "message": "View framework docs",
+    "description": "CTA - 프레임워크 문서 보기"
+  },
+  "homepage.cloud.badge.idling": {
+    "message": "Idling",
+    "description": "Cloud 상태 - 유휴"
+  },
+  "homepage.cloud.badge.scalingUp": {
+    "message": "Scaling up",
+    "description": "Cloud 상태 - 스케일 업"
+  },
+  "homepage.cloud.badge.scalingDown": {
+    "message": "Scaling down",
+    "description": "Cloud 상태 - 스케일 다운"
+  },
+  "homepage.cloud.title": {
+    "message": "Laravel Cloud takes you from local to live in seconds",
+    "description": "Cloud 카드 제목"
+  },
+  "homepage.cloud.desc": {
+    "message": "Stop guessing how many servers you need. Autoscale under load and hibernate when idle. Only pay for what you actually use.",
+    "description": "Cloud 카드 설명"
+  },
+  "homepage.cloud.feature.dashboard": {
+    "message": "Full control via dashboard or CLI",
+    "description": "Cloud 기능 1"
+  },
+  "homepage.cloud.feature.databases": {
+    "message": "Instantly add databases, workers, cache, and storage",
+    "description": "Cloud 기능 2"
+  },
+  "homepage.cloud.cta": {
+    "message": "Explore Laravel Cloud",
+    "description": "Cloud CTA 링크"
+  },
+  "homepage.preview.title": {
+    "message": "Check pull requests from your team (or agents) in preview environments",
+    "description": "Preview 카드 제목"
+  },
+  "homepage.preview.desc": {
+    "message": "Review every change in Cloud's zero-risk, production-like preview environment before it ever hits your main branch.",
+    "description": "Preview 카드 설명"
+  },
+  "homepage.preview.feature.ghActions": {
+    "message": "Integrates seamlessly with GitHub Actions",
+    "description": "Preview 기능 1"
+  },
+  "homepage.preview.feature.migrations": {
+    "message": "Safely test migrations and heavy changes",
+    "description": "Preview 기능 2"
+  },
+  "homepage.preview.cta": {
+    "message": "Explore Preview Environments",
+    "description": "Preview CTA 링크"
+  },
+  "homepage.events.label": {
+    "message": "Events",
+    "description": "Events 섹션 라벨"
+  },
+  "homepage.events.title.city": {
+    "message": "Events",
+    "description": "Events 섹션 제목 - 강조 단어"
+  },
+  "homepage.events.title.suffix": {
+    "message": " bring us together",
+    "description": "Events 섹션 제목 접미사 (강조 단어 뒤에 옴)"
+  },
+  "homepage.events.desc": {
+    "message": "Laravel is best known for its amazing community, where online friendships transform into real-world connections at Laracons, Lives, and meetups in over 34 countries.",
+    "description": "Events 섹션 설명"
+  },
+  "homepage.events.cta": {
+    "message": "Find nearby meetups",
+    "description": "Events CTA 링크"
+  },
+  "homepage.events.ticket": {
+    "message": "Claim your ticket",
+    "description": "이벤트 티켓 CTA"
+  },
+  "homepage.events.nav.prev": {
+    "message": "Previous event",
+    "description": "이벤트 캐러셀 이전 버튼 aria-label"
+  },
+  "homepage.events.nav.next": {
+    "message": "Next event",
+    "description": "이벤트 캐러셀 다음 버튼 aria-label"
+  },
+  "homepage.frontend.title": {
+    "message": "The perfect partner for any frontend",
+    "description": "Frontend 섹션 제목"
+  },
+  "homepage.frontend.desc": {
+    "message": "Use Laravel and Inertia to effortlessly build frontend experiences with React, Vue, and Svelte. Or speed up frontend development with Livewire.",
+    "description": "Frontend 섹션 설명"
+  },
+  "homepage.frontend.cta": {
+    "message": "Explore frontend",
+    "description": "Frontend CTA 링크"
+  },
+  "homepage.hero.title.part1": {
+    "message": "The clean stack for",
+    "description": "Hero H1 앞부분"
+  },
+  "homepage.hero.title.part2": {
+    "message": "Artisans and agents.",
+    "description": "Hero H1 뒷부분"
+  },
+  "homepage.hero.subtitle.part1": {
+    "message": "Laravel is batteries-included so everyone can",
+    "description": "Hero 서브타이틀 앞부분"
+  },
+  "homepage.hero.subtitle.part2": {
+    "message": "build and ship web apps at ridiculous speed.",
+    "description": "Hero 서브타이틀 뒷부분"
+  },
+  "homepage.hero.cta.viewDocs": {
+    "message": "View framework docs",
+    "description": "Hero CTA 버튼"
+  },
+  "homepage.nightwatch.title": {
+    "message": "Monitor and resolve issues with Nightwatch",
+    "description": "Nightwatch 섹션 제목"
+  },
+  "homepage.nightwatch.desc": {
+    "message": "Laravel Nightwatch gives your team complete observability, so you can catch application errors and key performance issues before anyone notices.",
+    "description": "Nightwatch 섹션 설명"
+  },
+  "homepage.nightwatch.feature.fix": {
+    "message": "Fix errors and performance issues with recommended solutions",
+    "description": "Nightwatch 기능 1"
+  },
+  "homepage.nightwatch.feature.trace": {
+    "message": "Trace requests, jobs, logs, commands, cache, and more",
+    "description": "Nightwatch 기능 2"
+  },
+  "homepage.nightwatch.feature.mcp": {
+    "message": "Let agents fix code directly with Nightwatch MCP",
+    "description": "Nightwatch 기능 3"
+  },
+  "homepage.nightwatch.cta": {
+    "message": "Explore Nightwatch",
+    "description": "Nightwatch CTA 링크"
+  },
+  "homepage.nightwatch.img.alt": {
+    "message": "Nightwatch dashboard screenshot",
+    "description": "Nightwatch 대시보드 이미지 alt"
+  },
+  "homepage.ai.heading.prefix": {
+    "message": "Ship web apps with the ",
+    "description": "AI 섹션 헤딩 앞부분"
+  },
+  "homepage.ai.heading.enabled": {
+    "message": "AI-enabled",
+    "description": "AI 섹션 헤딩 - AI 활성"
+  },
+  "homepage.ai.heading.ready": {
+    "message": "AI-ready",
+    "description": "AI 섹션 헤딩 - AI 준비"
+  },
+  "homepage.ai.toggle.aria": {
+    "message": "Toggle AI",
+    "description": "AI 토글 버튼 aria-label"
+  },
+  "homepage.ai.heading.framework": {
+    "message": "framework.",
+    "description": "AI 섹션 헤딩 - 프레임워크"
+  },
+  "homepage.ai.subtext": {
+    "message": "We're ready when you're ready",
+    "description": "AI 섹션 서브텍스트"
+  },
+  "homepage.framework.heading.part1": {
+    "message": "A framework for",
+    "description": "Framework 섹션 제목 앞"
+  },
+  "homepage.framework.heading.part2": {
+    "message": "developers and agents",
+    "description": "Framework 섹션 제목 뒤"
+  },
+  "homepage.framework.desc": {
+    "message": "Laravel has opinions on everything: routing, queues, authentication, and more. That's thousands of decisions an agent doesn't have to make. The result? Clean code anyone can understand.",
+    "description": "Framework 섹션 설명"
+  },
+  "homepage.framework.feature.starterKits": {
+    "message": "Starter kits for React, Vue, and Svelte",
+    "description": "기능 목록 - 스타터 키트"
+  },
+  "homepage.framework.feature.aiSdk": {
+    "message": "AI SDK and AI assistant Boost",
+    "description": "기능 목록 - AI SDK"
+  },
+  "homepage.framework.feature.orm": {
+    "message": "Database ORM, queues, routing, and more",
+    "description": "기능 목록 - ORM"
+  },
+  "homepage.framework.feature.ecosystem": {
+    "message": "Ecosystem of 30+ open source packages",
+    "description": "기능 목록 - 에코시스템"
+  },
+  "homepage.framework.cta": {
+    "message": "Explore the framework",
+    "description": "Framework CTA 링크"
+  },
+  "homepage.framework.tabs.aria": {
+    "message": "Code categories",
+    "description": "카테고리 탭 aria-label"
+  },
   "theme.keywords": {
     "message": "Laravel, PHP framework, PHP artisan, PHP, web development, documentation, tutorial, getting started",
     "description": "The keywords meta tag for the site"

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -573,6 +573,226 @@
     "message": "Laravel - ウェブ職人のためのPHPフレームワーク",
     "description": "The image alt text for the homepage"
   },
+  "homepage.cta.title.part1": {
+    "message": "制限なく作りましょう。",
+    "description": "CTA 제목 앞"
+  },
+  "homepage.cta.title.part2": {
+    "message": "次に何をリリースしますか？",
+    "description": "CTA 제목 뒤"
+  },
+  "homepage.cta.deploy": {
+    "message": "Cloudにデプロイ",
+    "description": "CTA - 클라우드 배포 버튼"
+  },
+  "homepage.cta.docs": {
+    "message": "フレームワークのドキュメントを見る",
+    "description": "CTA - 프레임워크 문서 보기"
+  },
+  "homepage.cloud.badge.idling": {
+    "message": "アイドル中",
+    "description": "Cloud 상태 - 유휴"
+  },
+  "homepage.cloud.badge.scalingUp": {
+    "message": "スケールアップ中",
+    "description": "Cloud 상태 - 스케일 업"
+  },
+  "homepage.cloud.badge.scalingDown": {
+    "message": "スケールダウン中",
+    "description": "Cloud 상태 - 스케일 다운"
+  },
+  "homepage.cloud.title": {
+    "message": "Laravel Cloudならローカルから本番公開まで数秒",
+    "description": "Cloud 카드 제목"
+  },
+  "homepage.cloud.desc": {
+    "message": "必要なサーバー数を推測する必要はありません。負荷が高まれば自動でスケールアップし、アイドル時は休止します。実際に使った分だけ支払えます。",
+    "description": "Cloud 카드 설명"
+  },
+  "homepage.cloud.feature.dashboard": {
+    "message": "ダッシュボードまたはCLIから完全に制御",
+    "description": "Cloud 기능 1"
+  },
+  "homepage.cloud.feature.databases": {
+    "message": "データベース、ワーカー、キャッシュ、ストレージを即座に追加",
+    "description": "Cloud 기능 2"
+  },
+  "homepage.cloud.cta": {
+    "message": "Laravel Cloudを見る",
+    "description": "Cloud CTA 링크"
+  },
+  "homepage.preview.title": {
+    "message": "チーム（またはエージェント）のプルリクエストをプレビュー環境で確認",
+    "description": "Preview 카드 제목"
+  },
+  "homepage.preview.desc": {
+    "message": "メインブランチに入る前に、Cloudのリスクのない本番同等のプレビュー環境ですべての変更を確認できます。",
+    "description": "Preview 카드 설명"
+  },
+  "homepage.preview.feature.ghActions": {
+    "message": "GitHub Actionsとシームレスに連携",
+    "description": "Preview 기능 1"
+  },
+  "homepage.preview.feature.migrations": {
+    "message": "マイグレーションや大きな変更を安全にテスト",
+    "description": "Preview 기능 2"
+  },
+  "homepage.preview.cta": {
+    "message": "プレビュー環境を見る",
+    "description": "Preview CTA 링크"
+  },
+  "homepage.events.label": {
+    "message": "イベント",
+    "description": "Events 섹션 라벨"
+  },
+  "homepage.events.title.city": {
+    "message": "イベント",
+    "description": "Events 섹션 제목 - 강조 단어"
+  },
+  "homepage.events.title.suffix": {
+    "message": "で会いましょう",
+    "description": "Events 섹션 제목 접미사 (강조 단어 뒤에 옴)"
+  },
+  "homepage.events.desc": {
+    "message": "Laravelはすばらしいコミュニティで知られています。オンラインで始まったつながりが、34か国以上のLaracon、Live、ミートアップで実際の出会いになります。",
+    "description": "Events 섹션 설명"
+  },
+  "homepage.events.cta": {
+    "message": "近くのミートアップを探す",
+    "description": "Events CTA 링크"
+  },
+  "homepage.events.ticket": {
+    "message": "チケットを入手",
+    "description": "이벤트 티켓 CTA"
+  },
+  "homepage.events.nav.prev": {
+    "message": "前のイベント",
+    "description": "이벤트 캐러셀 이전 버튼 aria-label"
+  },
+  "homepage.events.nav.next": {
+    "message": "次のイベント",
+    "description": "이벤트 캐러셀 다음 버튼 aria-label"
+  },
+  "homepage.frontend.title": {
+    "message": "どんなフロントエンドにも合う最高のパートナー",
+    "description": "Frontend 섹션 제목"
+  },
+  "homepage.frontend.desc": {
+    "message": "LaravelとInertiaなら、React、Vue、Svelteを使ったフロントエンド体験を手軽に作れます。Livewireを使えば、フロントエンド開発をさらに速められます。",
+    "description": "Frontend 섹션 설명"
+  },
+  "homepage.frontend.cta": {
+    "message": "フロントエンドを見る",
+    "description": "Frontend CTA 링크"
+  },
+  "homepage.hero.title.part1": {
+    "message": "Artisanとエージェントのための",
+    "description": "Hero H1 앞부분"
+  },
+  "homepage.hero.title.part2": {
+    "message": "無駄のないスタック。",
+    "description": "Hero H1 뒷부분"
+  },
+  "homepage.hero.subtitle.part1": {
+    "message": "Laravelは必要なものが最初から揃っているので、誰でも",
+    "description": "Hero 서브타이틀 앞부분"
+  },
+  "homepage.hero.subtitle.part2": {
+    "message": "驚くほど速くWebアプリを作ってリリースできます。",
+    "description": "Hero 서브타이틀 뒷부분"
+  },
+  "homepage.hero.cta.viewDocs": {
+    "message": "フレームワークのドキュメントを見る",
+    "description": "Hero CTA 버튼"
+  },
+  "homepage.nightwatch.title": {
+    "message": "Nightwatchで問題を監視して解決",
+    "description": "Nightwatch 섹션 제목"
+  },
+  "homepage.nightwatch.desc": {
+    "message": "Laravel Nightwatchは、チームが気づく前にアプリのエラーや重要なパフォーマンス問題を見つけられる完全なオブザーバビリティを提供します。",
+    "description": "Nightwatch 섹션 설명"
+  },
+  "homepage.nightwatch.feature.fix": {
+    "message": "推奨される解決策でエラーとパフォーマンス問題を修正",
+    "description": "Nightwatch 기능 1"
+  },
+  "homepage.nightwatch.feature.trace": {
+    "message": "リクエスト、ジョブ、ログ、コマンド、キャッシュなどを追跡",
+    "description": "Nightwatch 기능 2"
+  },
+  "homepage.nightwatch.feature.mcp": {
+    "message": "Nightwatch MCPでエージェントが直接コードを修正",
+    "description": "Nightwatch 기능 3"
+  },
+  "homepage.nightwatch.cta": {
+    "message": "Nightwatchを見る",
+    "description": "Nightwatch CTA 링크"
+  },
+  "homepage.nightwatch.img.alt": {
+    "message": "Nightwatchダッシュボードのスクリーンショット",
+    "description": "Nightwatch 대시보드 이미지 alt"
+  },
+  "homepage.ai.heading.prefix": {
+    "message": "Webアプリをリリースしましょう、",
+    "description": "AI 섹션 헤딩 앞부분"
+  },
+  "homepage.ai.heading.enabled": {
+    "message": "AI搭載",
+    "description": "AI 섹션 헤딩 - AI 활성"
+  },
+  "homepage.ai.heading.ready": {
+    "message": "AI対応",
+    "description": "AI 섹션 헤딩 - AI 준비"
+  },
+  "homepage.ai.toggle.aria": {
+    "message": "AI切り替え",
+    "description": "AI 토글 버튼 aria-label"
+  },
+  "homepage.ai.heading.framework": {
+    "message": "フレームワークで。",
+    "description": "AI 섹션 헤딩 - 프레임워크"
+  },
+  "homepage.ai.subtext": {
+    "message": "あなたの準備ができたら、こちらも準備できています",
+    "description": "AI 섹션 서브텍스트"
+  },
+  "homepage.framework.heading.part1": {
+    "message": "開発者と",
+    "description": "Framework 섹션 제목 앞"
+  },
+  "homepage.framework.heading.part2": {
+    "message": "エージェントのためのフレームワーク",
+    "description": "Framework 섹션 제목 뒤"
+  },
+  "homepage.framework.desc": {
+    "message": "Laravelはルーティング、キュー、認証など、あらゆる領域に明確な方針を持っています。つまり、エージェントが悩む必要のない何千もの判断がすでに決まっています。その結果、誰でも理解できるクリーンなコードになります。",
+    "description": "Framework 섹션 설명"
+  },
+  "homepage.framework.feature.starterKits": {
+    "message": "React、Vue、Svelte向けスターターキット",
+    "description": "기능 목록 - 스타터 키트"
+  },
+  "homepage.framework.feature.aiSdk": {
+    "message": "AI SDKとAIアシスタントBoost",
+    "description": "기능 목록 - AI SDK"
+  },
+  "homepage.framework.feature.orm": {
+    "message": "データベースORM、キュー、ルーティングなど",
+    "description": "기능 목록 - ORM"
+  },
+  "homepage.framework.feature.ecosystem": {
+    "message": "30以上のオープンソースパッケージによるエコシステム",
+    "description": "기능 목록 - 에코시스템"
+  },
+  "homepage.framework.cta": {
+    "message": "フレームワークを見る",
+    "description": "Framework CTA 링크"
+  },
+  "homepage.framework.tabs.aria": {
+    "message": "コードカテゴリ",
+    "description": "카테고리 탭 aria-label"
+  },
   "theme.keywords": {
     "message": "Laravel, PHPフレームワーク, PHP artisan, PHP, ウェブ開発, ドキュメント, チュートリアル, はじめに",
     "description": "The keywords meta tag for the site"

--- a/src/components/Homepage/CTASection.tsx
+++ b/src/components/Homepage/CTASection.tsx
@@ -1,5 +1,6 @@
 import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
 
 export default function CTASection(): ReactNode {
   return (
@@ -17,12 +18,12 @@ export default function CTASection(): ReactNode {
               <path fill="currentColor" fillRule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638L10.23 5.29a.75.75 0 1 1 1.04-1.08l5.5 5.25a.75.75 0 0 1 0 1.08l-5.5 5.25a.75.75 0 1 1-1.04-1.08l4.158-3.96H3.75A.75.75 0 0 1 3 10Z" clipRule="evenodd" />
             </svg>
           </a>
-          <a href="/docs/12.x" className="explore-btn">
+          <Link to="/docs/12.x" className="explore-btn">
             <Translate id="homepage.cta.docs" description="CTA - 프레임워크 문서 보기">프레임워크 문서 보기</Translate>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16" className="explore-btn-icon" aria-hidden="true">
               <path fillRule="evenodd" d="M5.22 14.78a.75.75 0 0 0 1.06 0l7.22-7.22v5.69a.75.75 0 0 0 1.5 0v-7.5a.75.75 0 0 0-.75-.75h-7.5a.75.75 0 0 0 0 1.5h5.69l-7.22 7.22a.75.75 0 0 0 0 1.06Z" clipRule="evenodd" />
             </svg>
-          </a>
+          </Link>
         </div>
       </div>
     </section>

--- a/src/components/Homepage/CTASection.tsx
+++ b/src/components/Homepage/CTASection.tsx
@@ -1,19 +1,24 @@
 import React, {type ReactNode} from 'react';
+import Translate from '@docusaurus/Translate';
 
 export default function CTASection(): ReactNode {
   return (
     <section className="cta-section hp-section hp-section-bordered">
       <div className="container">
-        <h2>Create without limits.<br />What will you ship?</h2>
+        <h2>
+          <Translate id="homepage.cta.title.part1" description="CTA 제목 앞">한계 없이 만들어 보세요.</Translate>
+          <br />
+          <Translate id="homepage.cta.title.part2" description="CTA 제목 뒤">무엇을 만들어 내시겠습니까?</Translate>
+        </h2>
         <div className="cta-buttons">
           <a href="https://cloud.laravel.com" className="cta-primary" target="_blank" rel="noopener noreferrer">
-            Deploy on Cloud
+            <Translate id="homepage.cta.deploy" description="CTA - 클라우드 배포 버튼">Cloud에 배포하기</Translate>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="18" height="18" className="cta-arrow-icon" aria-hidden="true">
               <path fill="currentColor" fillRule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638L10.23 5.29a.75.75 0 1 1 1.04-1.08l5.5 5.25a.75.75 0 0 1 0 1.08l-5.5 5.25a.75.75 0 1 1-1.04-1.08l4.158-3.96H3.75A.75.75 0 0 1 3 10Z" clipRule="evenodd" />
             </svg>
           </a>
           <a href="/docs/12.x" className="explore-btn">
-            View framework docs
+            <Translate id="homepage.cta.docs" description="CTA - 프레임워크 문서 보기">프레임워크 문서 보기</Translate>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16" className="explore-btn-icon" aria-hidden="true">
               <path fillRule="evenodd" d="M5.22 14.78a.75.75 0 0 0 1.06 0l7.22-7.22v5.69a.75.75 0 0 0 1.5 0v-7.5a.75.75 0 0 0-.75-.75h-7.5a.75.75 0 0 0 0 1.5h5.69l-7.22 7.22a.75.75 0 0 0 0 1.06Z" clipRule="evenodd" />
             </svg>

--- a/src/components/Homepage/CloudSection.tsx
+++ b/src/components/Homepage/CloudSection.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useEffect, type ReactNode} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Translate from '@docusaurus/Translate';
 import {CheckIcon, ArrowIcon} from './SharedIcons';
 
 function IdlingIcon(): ReactNode {
@@ -30,9 +31,24 @@ function ScalingDownIcon(): ReactNode {
 }
 
 const BADGES = [
-  {label: 'Idling', icon: <IdlingIcon />, accent: '#2563EB99'},
-  {label: 'Scaling up', icon: <ScalingUpIcon />, accent: '#05966999'},
-  {label: 'Scaling down', icon: <ScalingDownIcon />, accent: '#F59E0B99'},
+  {
+    key: 'idling',
+    label: <Translate id="homepage.cloud.badge.idling" description="Cloud 상태 - 유휴">유휴 중</Translate>,
+    icon: <IdlingIcon />,
+    accent: '#2563EB99',
+  },
+  {
+    key: 'scalingUp',
+    label: <Translate id="homepage.cloud.badge.scalingUp" description="Cloud 상태 - 스케일 업">스케일 업 중</Translate>,
+    icon: <ScalingUpIcon />,
+    accent: '#05966999',
+  },
+  {
+    key: 'scalingDown',
+    label: <Translate id="homepage.cloud.badge.scalingDown" description="Cloud 상태 - 스케일 다운">스케일 다운 중</Translate>,
+    icon: <ScalingDownIcon />,
+    accent: '#F59E0B99',
+  },
 ] as const;
 
 function AutoscaleIllustration(): ReactNode {
@@ -52,7 +68,7 @@ function AutoscaleIllustration(): ReactNode {
         <div className="cloud-badge-container">
           {BADGES.map((badge, idx) => (
             <div
-              key={badge.label}
+              key={badge.key}
               className={`cloud-status-badge ${idx === activeIdx ? 'cloud-status-badge--active' : ''}`}
               style={{'--badge-accent': badge.accent} as React.CSSProperties}
             >
@@ -237,24 +253,29 @@ export default function CloudSection(): ReactNode {
           {/* Cloud card */}
           <div className="cloud-card">
             <div className="cloud-card-content">
-              <h3>Laravel Cloud takes you{' '}<br className="tablet-br" />from local{' '}<br className="mobile-br" />to live in{' '}<br className="tablet-br" />seconds</h3>
+              <h3>
+                <Translate id="homepage.cloud.title" description="Cloud 카드 제목">
+                  Laravel Cloud로 로컬에서 라이브까지 단 몇 초 만에
+                </Translate>
+              </h3>
               <p>
-                No more guessing how many servers you{' '}<br className="tablet-br" />need: autoscale up under load
-                and{' '}<br className="tablet-br" />hibernate when{' '}<br className="desktop-only-br" />idle. Only pay for what{' '}<br className="tablet-br" />you actually use.
+                <Translate id="homepage.cloud.desc" description="Cloud 카드 설명">
+                  필요한 서버 수를 추측할 필요가 없습니다. 부하가 몰리면 자동으로 스케일 업되고, 유휴 상태에는 절전 모드로 전환됩니다. 실제로 사용한 만큼만 비용을 내세요.
+                </Translate>
               </p>
               <ul className="cloud-feature-list">
                 <li>
                   <CheckIcon className="cloud-check-icon" />
-                  <span>Full control via dashboard or CLI</span>
+                  <span><Translate id="homepage.cloud.feature.dashboard" description="Cloud 기능 1">대시보드 또는 CLI를 통한 완전한 제어</Translate></span>
                 </li>
                 <li>
                   <CheckIcon className="cloud-check-icon" />
-                  <span>Instantly add databases, workers,{' '}<br className="tablet-br" />cache, and storage</span>
+                  <span><Translate id="homepage.cloud.feature.databases" description="Cloud 기능 2">데이터베이스, 워커, 캐시, 스토리지 즉시 추가</Translate></span>
                 </li>
               </ul>
               <div className="cloud-btn-wrapper">
                 <a href="https://cloud.laravel.com" className="explore-btn">
-                  Explore Laravel Cloud
+                  <Translate id="homepage.cloud.cta" description="Cloud CTA 링크">Laravel Cloud 살펴보기</Translate>
                   <ArrowIcon />
                 </a>
               </div>
@@ -267,19 +288,24 @@ export default function CloudSection(): ReactNode {
           {/* Preview card */}
           <div className="preview-card">
             <div className="cloud-card-content">
-              <h3>Check pull requests from{' '}<br className="tablet-br" />your{' '}<br className="mobile-br" />team (or agents) in{' '}<br className="tablet-br" />preview{' '}<br className="mobile-br" />environments</h3>
+              <h3>
+                <Translate id="homepage.preview.title" description="Preview 카드 제목">
+                  팀(또는 에이전트)의 풀 리퀘스트를 프리뷰 환경에서 확인하세요
+                </Translate>
+              </h3>
               <p>
-                Review every change in Cloud's zero-risk,{' '}<br className="tablet-br" />production-{' '}<br className="mobile-br" />like{' '}<br className="desktop-only-br" />preview
-                environment{' '}<br className="tablet-br" />before it ever hits your main{' '}<br className="mobile-br" />branch.
+                <Translate id="homepage.preview.desc" description="Preview 카드 설명">
+                  메인 브랜치에 병합하기 전, 실제 운영 환경과 똑같이 동작하는 Cloud 프리뷰 환경에서 모든 변경을 안전하게 검토하세요.
+                </Translate>
               </p>
               <ul className="cloud-feature-list">
                 <li>
                   <CheckIcon className="cloud-check-icon" />
-                  <span>Integrates seamlessly with GitHub{' '}<br className="tablet-br" />Actions</span>
+                  <span><Translate id="homepage.preview.feature.ghActions" description="Preview 기능 1">GitHub Actions와 원활한 통합</Translate></span>
                 </li>
                 <li>
                   <CheckIcon className="cloud-check-icon" />
-                  <span>Test migrations and heavy changes{' '}<br className="tablet-br" />safely</span>
+                  <span><Translate id="homepage.preview.feature.migrations" description="Preview 기능 2">마이그레이션과 대규모 변경을 안전하게 테스트</Translate></span>
                 </li>
               </ul>
               <div className="cloud-btn-wrapper">
@@ -287,7 +313,7 @@ export default function CloudSection(): ReactNode {
                   href="https://cloud.laravel.com/docs/preview-environments"
                   className="explore-btn"
                 >
-                  Explore Preview Environments
+                  <Translate id="homepage.preview.cta" description="Preview CTA 링크">프리뷰 환경 살펴보기</Translate>
                   <ArrowIcon />
                 </a>
               </div>

--- a/src/components/Homepage/EventsSection.tsx
+++ b/src/components/Homepage/EventsSection.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useRef, useCallback, useEffect, type ReactNode} from 'react';
+import React, {useState, useRef, useCallback, type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import {ArrowIcon} from './SharedIcons';
 
@@ -65,23 +65,9 @@ export default function EventsSection(): ReactNode {
   // Build slides: [clone-last, ...originals, clone-first]
   const slides = [events[total - 1], ...events, events[0]];
 
-  const realIndex = ((pos - 1) % total + total) % total;
-  const activeEvent = events[realIndex];
-
-  // City slide-up animation
-  const [displayCity, setDisplayCity] = useState(activeEvent.cityKo);
-  const [cityAnimating, setCityAnimating] = useState(false);
-
-  useEffect(() => {
-    if (activeEvent.cityKo !== displayCity) {
-      setCityAnimating(true);
-      const timer = setTimeout(() => {
-        setDisplayCity(activeEvent.cityKo);
-        setCityAnimating(false);
-      }, 200);
-      return () => clearTimeout(timer);
-    }
-  }, [activeEvent.cityKo, displayCity]);
+  // 캐러셀 비활성 동안 displayCity / cityAnimating 애니메이션 상태 제거.
+  // 재활성 시 H2 의 <Translate id="homepage.events.title.city"> 자리를
+  // {displayCity} 로 돌리고 관련 state / useEffect 를 복구할 것.
 
   const handleTransitionEnd = useCallback(() => {
     isTransitioning.current = false;
@@ -129,11 +115,11 @@ export default function EventsSection(): ReactNode {
           </div>
           <h2>
             <span className="events-city-wrapper">
-              <span className={`events-city-highlight ${cityAnimating ? 'events-city--out' : 'events-city--in'}`}>
-                {displayCity}
+              <span className="events-city-highlight events-city--in">
+                <Translate id="homepage.events.title.city" description="Events 섹션 제목 - 강조 단어">이벤트</Translate>
               </span>
             </span>
-            <Translate id="homepage.events.title.suffix" description="Events 섹션 제목 접미사 (도시명 뒤에 옴)">에서 만나요</Translate>
+            <Translate id="homepage.events.title.suffix" description="Events 섹션 제목 접미사 (강조 단어 뒤에 옴)">에서 만나요</Translate>
           </h2>
           <p className="events-description">
             <Translate id="homepage.events.desc" description="Events 섹션 설명">
@@ -149,7 +135,8 @@ export default function EventsSection(): ReactNode {
         </div>
       </section>
 
-      {/* Carousel - single track, slides overflow into viewport gutters */}
+      {/* Carousel - 일시 비활성화 (단일 트랙, 슬라이드가 뷰포트 거터로 넘침) */}
+      {false && (
       <section className="events-carousel-section">
         <div className="events-carousel-container">
           <div
@@ -201,6 +188,7 @@ export default function EventsSection(): ReactNode {
           </button>
         </div>
       </section>
+      )}
     </>
   );
 }

--- a/src/components/Homepage/EventsSection.tsx
+++ b/src/components/Homepage/EventsSection.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useRef, useCallback, useEffect, type ReactNode} from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
 import {ArrowIcon} from './SharedIcons';
 
 const events = [
@@ -7,6 +8,7 @@ const events = [
     date: 'May 26-27',
     year: '2026',
     city: 'Tokyo',
+    cityKo: '도쿄',
     country: 'JP',
     ticketUrl: 'https://laravellive.jp/en',
     image: '/images/home/event-japan.webp',
@@ -18,6 +20,7 @@ const events = [
     date: 'Jun 18-19',
     year: '2026',
     city: 'London',
+    cityKo: '런던',
     country: 'UK',
     ticketUrl: 'https://laravellive.uk/',
     image: '/images/home/event-uk.webp',
@@ -29,6 +32,7 @@ const events = [
     date: 'Jul 28-29',
     year: '2026',
     city: 'Boston',
+    cityKo: '보스턴',
     country: 'US',
     ticketUrl: 'https://laracon.us',
     image: '/images/home/event-us.webp',
@@ -41,6 +45,7 @@ const events = [
     date: 'Aug 20-21',
     year: '2026',
     city: 'Copenhagen',
+    cityKo: '코펜하겐',
     country: 'DK',
     ticketUrl: 'https://laravellive.dk/',
     image: '/images/home/event-dk.webp',
@@ -64,19 +69,19 @@ export default function EventsSection(): ReactNode {
   const activeEvent = events[realIndex];
 
   // City slide-up animation
-  const [displayCity, setDisplayCity] = useState(activeEvent.city);
+  const [displayCity, setDisplayCity] = useState(activeEvent.cityKo);
   const [cityAnimating, setCityAnimating] = useState(false);
 
   useEffect(() => {
-    if (activeEvent.city !== displayCity) {
+    if (activeEvent.cityKo !== displayCity) {
       setCityAnimating(true);
       const timer = setTimeout(() => {
-        setDisplayCity(activeEvent.city);
+        setDisplayCity(activeEvent.cityKo);
         setCityAnimating(false);
       }, 200);
       return () => clearTimeout(timer);
     }
-  }, [activeEvent.city, displayCity]);
+  }, [activeEvent.cityKo, displayCity]);
 
   const handleTransitionEnd = useCallback(() => {
     isTransitioning.current = false;
@@ -119,23 +124,25 @@ export default function EventsSection(): ReactNode {
         <div className="container">
           <div className="events-label">
             <span className="events-bracket">[</span>
-            <span>Events</span>
+            <span><Translate id="homepage.events.label" description="Events 섹션 라벨">Events</Translate></span>
             <span className="events-bracket">]</span>
           </div>
-          <h2>We'll see you in{' '}
+          <h2>
             <span className="events-city-wrapper">
               <span className={`events-city-highlight ${cityAnimating ? 'events-city--out' : 'events-city--in'}`}>
                 {displayCity}
               </span>
             </span>
+            <Translate id="homepage.events.title.suffix" description="Events 섹션 제목 접미사 (도시명 뒤에 옴)">에서 만나요</Translate>
           </h2>
           <p className="events-description">
-            Laravel is best known for its amazing community,{' '}<br className="mobile-br" />where online friendships{' '}<br className="tablet-br" />transform{' '}<br className="desktop-only-br" />
-            into real-{' '}<br className="mobile-br" />world connections at Laracons, Lives, and{' '}<br className="mobile-br" />meetups in over{' '}<br className="tablet-br" />34 countries.
+            <Translate id="homepage.events.desc" description="Events 섹션 설명">
+              라라벨은 멋진 커뮤니티로 유명합니다. 온라인에서 시작된 우정이 34개가 넘는 국가의 Laracon, Live, 밋업에서 실제 만남으로 이어집니다.
+            </Translate>
           </p>
           <div className="events-link-wrapper">
-            <a href="/events" className="explore-btn">
-              Find nearby meetups
+            <a href="https://laravel.com/events" className="explore-btn" target="_blank" rel="noopener noreferrer">
+              <Translate id="homepage.events.cta" description="Events CTA 링크">근처 밋업 찾기</Translate>
               <ArrowIcon />
             </a>
           </div>
@@ -167,7 +174,7 @@ export default function EventsSection(): ReactNode {
                       <div className="events-slide-meta">
                         <div className="events-slide-date">{event.date}</div>
                         <div className="events-slide-year">{event.year}</div>
-                        <div className="events-slide-city">{event.city}</div>
+                        <div className="events-slide-city">{event.cityKo}</div>
                         <div className="events-slide-country">{event.country}</div>
                       </div>
                     </div>
@@ -177,7 +184,7 @@ export default function EventsSection(): ReactNode {
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      Claim your ticket
+                      <Translate id="homepage.events.ticket" description="이벤트 티켓 CTA">티켓 받기</Translate>
                       <ArrowIcon />
                     </a>
                   </div>
@@ -186,10 +193,10 @@ export default function EventsSection(): ReactNode {
             ))}
           </div>
 
-          <button className="events-nav-btn events-nav-btn--prev" onClick={goPrev} aria-label="Previous event" type="button">
+          <button className="events-nav-btn events-nav-btn--prev" onClick={goPrev} aria-label={translate({id: 'homepage.events.nav.prev', message: '이전 이벤트', description: '이벤트 캐러셀 이전 버튼 aria-label'})} type="button">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M15 18l-6-6 6-6" /></svg>
           </button>
-          <button className="events-nav-btn events-nav-btn--next" onClick={goNext} aria-label="Next event" type="button">
+          <button className="events-nav-btn events-nav-btn--next" onClick={goNext} aria-label={translate({id: 'homepage.events.nav.next', message: '다음 이벤트', description: '이벤트 캐러셀 다음 버튼 aria-label'})} type="button">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M9 18l6-6-6-6" /></svg>
           </button>
         </div>

--- a/src/components/Homepage/EventsSection.tsx
+++ b/src/components/Homepage/EventsSection.tsx
@@ -2,6 +2,9 @@ import React, {useState, useRef, useCallback, type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
 import {ArrowIcon} from './SharedIcons';
 
+// 캐러셀 일시 비활성 플래그. 재활성 시 true 로 변경.
+const SHOW_CAROUSEL = false;
+
 const events = [
   {
     name: 'Laravel Live Japan',
@@ -136,7 +139,7 @@ export default function EventsSection(): ReactNode {
       </section>
 
       {/* Carousel - 일시 비활성화 (단일 트랙, 슬라이드가 뷰포트 거터로 넘침) */}
-      {false && (
+      {SHOW_CAROUSEL && (
       <section className="events-carousel-section">
         <div className="events-carousel-container">
           <div

--- a/src/components/Homepage/FrameworkSection.tsx
+++ b/src/components/Homepage/FrameworkSection.tsx
@@ -1,5 +1,6 @@
 import React, {useState, type ReactNode} from 'react';
 import Translate, {translate} from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
 import {CheckIcon, ArrowIcon} from './SharedIcons';
 
 function LaravelFileIcon(): ReactNode {
@@ -510,10 +511,10 @@ export default function FrameworkSection(): ReactNode {
               <li><CheckIcon /> <Translate id="homepage.framework.feature.orm" description="기능 목록 - ORM">데이터베이스 ORM, 큐, 라우팅 등</Translate></li>
               <li><CheckIcon /> <Translate id="homepage.framework.feature.ecosystem" description="기능 목록 - 에코시스템">30개가 넘는 오픈소스 패키지 생태계</Translate></li>
             </ul>
-            <a href="/docs/12.x" className="explore-btn">
+            <Link to="/docs/12.x" className="explore-btn">
               <Translate id="homepage.framework.cta" description="Framework CTA 링크">프레임워크 살펴보기</Translate>
               <ArrowIcon className="explore-btn-icon" />
-            </a>
+            </Link>
           </div>
 
           <div className="code-area">

--- a/src/components/Homepage/FrameworkSection.tsx
+++ b/src/components/Homepage/FrameworkSection.tsx
@@ -1,4 +1,5 @@
 import React, {useState, type ReactNode} from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
 import {CheckIcon, ArrowIcon} from './SharedIcons';
 
 function LaravelFileIcon(): ReactNode {
@@ -380,23 +381,29 @@ export function AIFrameworkSection(): ReactNode {
     <section className="ai-framework-section hp-section hp-section-bordered">
       <div className="container">
         <h2 className="ai-heading">
-          Ship web apps with the<br />
+          <Translate id="homepage.ai.heading.prefix" description="AI 섹션 헤딩 앞부분">웹 앱을 출시하세요,&nbsp;</Translate><br />
           <span className="ai-heading-line2">
-            {aiEnabled ? 'AI‑enabled' : 'AI‑ready'}{' '}
+            {aiEnabled
+              ? <Translate id="homepage.ai.heading.enabled" description="AI 섹션 헤딩 - AI 활성">AI가 탑재된</Translate>
+              : <Translate id="homepage.ai.heading.ready" description="AI 섹션 헤딩 - AI 준비">AI를 맞을 준비가 된</Translate>
+            }{' '}
             <button
               className={`ai-toggle-inline ${aiEnabled ? 'ai-toggle--on' : ''}`}
               onClick={() => setAiEnabled(prev => !prev)}
               aria-pressed={aiEnabled}
-              aria-label="Toggle AI"
+              aria-label={translate({id: 'homepage.ai.toggle.aria', message: 'AI 활성화 토글', description: 'AI 토글 버튼 aria-label'})}
             >
               <span className="ai-toggle-track">
                 <span className="ai-toggle-thumb" />
               </span>
             </button>
-            <br className="mobile-br" />{' '}framework
+            <br className="mobile-br" />{' '}
+            <Translate id="homepage.ai.heading.framework" description="AI 섹션 헤딩 - 프레임워크">프레임워크로.</Translate>
           </span>
         </h2>
-        <p className={`ai-subtext ${aiEnabled ? 'ai-subtext--hidden' : ''}`}>We're ready when you're ready</p>
+        <p className={`ai-subtext ${aiEnabled ? 'ai-subtext--hidden' : ''}`}>
+          <Translate id="homepage.ai.subtext" description="AI 섹션 서브텍스트">여러분이 준비됐을 때, 우리도 준비되어 있습니다</Translate>
+        </p>
       </div>
     </section>
   );
@@ -487,18 +494,24 @@ export default function FrameworkSection(): ReactNode {
       <div className="container framework-container">
         <div className="framework-grid">
           <div className="framework-info">
-            <h3>A framework for{' '}<br className="not-mobile-br" />developers{' '}<br className="mobile-br" />and agents</h3>
+            <h3>
+              <Translate id="homepage.framework.heading.part1" description="Framework 섹션 제목 앞">개발자와</Translate>
+              {' '}<br className="not-mobile-br" />
+              <Translate id="homepage.framework.heading.part2" description="Framework 섹션 제목 뒤">에이전트를 위한 프레임워크</Translate>
+            </h3>
             <p>
-              Laravel has opinions on everything: routing, queues,{' '}<br className="tablet-br" /><br className="mobile-br" />authentication, and more. That's thousands of{' '}<br className="tablet-br" />decisions{' '}<br className="mobile-br" />an agent doesn't have to make. The result? Clean code{' '}<br className="mobile-br" />that anyone can understand.
+              <Translate id="homepage.framework.desc" description="Framework 섹션 설명">
+                Laravel은 라우팅, 큐, 인증 등 모든 영역에 분명한 기준을 제시합니다. 에이전트가 고민할 필요 없는 수천 가지 결정이 이미 정해져 있다는 뜻이죠. 결과는? 누구나 읽을 수 있는 깔끔한 코드입니다.
+              </Translate>
             </p>
             <ul className="feature-list">
-              <li><CheckIcon /> Starter kits for React, Vue, and Svelte</li>
-              <li><CheckIcon /> AI SDK and Boost AI assistant</li>
-              <li><CheckIcon /> Database ORM, queues, routing, and more</li>
-              <li><CheckIcon /> Open source ecosystem of over 30 packages</li>
+              <li><CheckIcon /> <Translate id="homepage.framework.feature.starterKits" description="기능 목록 - 스타터 키트">React, Vue, Svelte용 스타터 키트</Translate></li>
+              <li><CheckIcon /> <Translate id="homepage.framework.feature.aiSdk" description="기능 목록 - AI SDK">AI SDK와 AI 어시스턴트 Boost</Translate></li>
+              <li><CheckIcon /> <Translate id="homepage.framework.feature.orm" description="기능 목록 - ORM">데이터베이스 ORM, 큐, 라우팅 등</Translate></li>
+              <li><CheckIcon /> <Translate id="homepage.framework.feature.ecosystem" description="기능 목록 - 에코시스템">30개가 넘는 오픈소스 패키지 생태계</Translate></li>
             </ul>
-            <a href="https://laravel.com/docs/" className="explore-btn">
-              Explore the framework
+            <a href="/docs/12.x" className="explore-btn">
+              <Translate id="homepage.framework.cta" description="Framework CTA 링크">프레임워크 살펴보기</Translate>
               <ArrowIcon className="explore-btn-icon" />
             </a>
           </div>
@@ -506,7 +519,7 @@ export default function FrameworkSection(): ReactNode {
           <div className="code-area">
             {/* Category tabs - pill style */}
             <div className="category-tabs-wrapper">
-              <ul className="category-tabs" role="toolbar" aria-label="Code categories">
+              <ul className="category-tabs" role="toolbar" aria-label={translate({id: 'homepage.framework.tabs.aria', message: '코드 카테고리', description: '카테고리 탭 aria-label'})}>
                 {categories.map((cat, idx) => (
                   <li key={cat.name} className="category-tab-item">
                     {idx === activeCategory && (

--- a/src/components/Homepage/FrontendSection.tsx
+++ b/src/components/Homepage/FrontendSection.tsx
@@ -1,5 +1,6 @@
 import React, {type ReactNode} from 'react';
 import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
 import {ArrowIcon, NoiseOverlay} from './SharedIcons';
 
 /* Stroke-based outline icons matching laravel.com style */
@@ -69,10 +70,10 @@ export default function FrontendSection(): ReactNode {
               </Translate>
             </p>
             <div className="frontend-btn-wrapper">
-              <a href="/docs/12.x/frontend" className="explore-btn">
+              <Link to="/docs/12.x/frontend" className="explore-btn">
                 <Translate id="homepage.frontend.cta" description="Frontend CTA 링크">프런트엔드 살펴보기</Translate>
                 <ArrowIcon />
-              </a>
+              </Link>
             </div>
           </div>
 

--- a/src/components/Homepage/FrontendSection.tsx
+++ b/src/components/Homepage/FrontendSection.tsx
@@ -1,4 +1,5 @@
 import React, {type ReactNode} from 'react';
+import Translate from '@docusaurus/Translate';
 import {ArrowIcon, NoiseOverlay} from './SharedIcons';
 
 /* Stroke-based outline icons matching laravel.com style */
@@ -57,15 +58,19 @@ export default function FrontendSection(): ReactNode {
         <NoiseOverlay className="frontend-noise-overlay" />
         <div className="frontend-grid">
           <div className="frontend-info">
-            <h3>The best partner to any{' '}<br className="tablet-br" />front-end</h3>
+            <h3>
+              <Translate id="homepage.frontend.title" description="Frontend 섹션 제목">
+                어떤 프런트엔드와도 어울리는 최고의 파트너
+              </Translate>
+            </h3>
             <p>
-              Easily craft frontend experiences with{' '}<br className="tablet-br" />React, Vue, or Svelte
-              alongside Laravel{' '}<br className="desktop-only-br" /><br className="tablet-br" />and Inertia. Or, accelerate your front-end{' '}<br className="tablet-br" />
-              development with Livewire.
+              <Translate id="homepage.frontend.desc" description="Frontend 섹션 설명">
+                Laravel과 Inertia로 React, Vue, Svelte를 활용한 프런트엔드 경험을 손쉽게 만들어 보세요. 또는 Livewire로 프런트엔드 개발 속도를 끌어올릴 수 있습니다.
+              </Translate>
             </p>
             <div className="frontend-btn-wrapper">
-              <a href="https://laravel.com/docs/frontend" className="explore-btn">
-                Explore front-ends
+              <a href="/docs/12.x/frontend" className="explore-btn">
+                <Translate id="homepage.frontend.cta" description="Frontend CTA 링크">프런트엔드 살펴보기</Translate>
                 <ArrowIcon />
               </a>
             </div>

--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -4,6 +4,7 @@ import Translate from '@docusaurus/Translate';
 
 export default function HeroSection(): ReactNode {
   const [svgContent, setSvgContent] = useState<string>('');
+  const [svgStatus, setSvgStatus] = useState<'loading' | 'loaded' | 'failed'>('loading');
   const svgRef = useRef<HTMLDivElement>(null);
   const heroSvgUrl = useBaseUrl('/images/home/hero-illustration.svg');
   const avatarUrl = useBaseUrl('/images/home/taylor-otwell.avif');
@@ -11,13 +12,21 @@ export default function HeroSection(): ReactNode {
 
   useEffect(() => {
     const controller = new AbortController();
+    setSvgStatus('loading');
+    setSvgContent('');
     fetch(heroSvgUrl, {signal: controller.signal})
       .then(res => {
         if (!res.ok) throw new Error(`Failed to fetch SVG: ${res.status}`);
         return res.text();
       })
-      .then(text => setSvgContent(text))
-      .catch(() => {});
+      .then(text => {
+        setSvgContent(text);
+        setSvgStatus('loaded');
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setSvgStatus('failed');
+      });
     return () => controller.abort();
   }, [heroSvgUrl]);
 
@@ -344,13 +353,13 @@ export default function HeroSection(): ReactNode {
               className="hero-illustration-svg"
               dangerouslySetInnerHTML={{__html: svgContent}}
             />
-          ) : (
+          ) : svgStatus === 'failed' ? (
             <img
               className="hero-illustration-svg"
               src={heroFallbackUrl}
               alt=""
             />
-          )}
+          ) : null}
         </div>
 
         {/* child 3: grain noise overlay */}

--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -1,3 +1,7 @@
+// Homepage 컴포넌트들의 <Translate> / translate() 메시지는 컴포넌트 내
+// 기본값으로 한국어 카피를 담고 있다. 번역 파일로 분리해 관리하려면
+//   npx docusaurus write-translations --locale ko
+// 을 실행해 i18n/ko/code.json 에 추출한 뒤 운영하면 된다.
 import React, {useEffect, useRef, useState, type ReactNode} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Translate from '@docusaurus/Translate';

--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useRef, useState, type ReactNode} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Translate from '@docusaurus/Translate';
 
 export default function HeroSection(): ReactNode {
   const [svgContent, setSvgContent] = useState<string>('');
@@ -314,13 +315,19 @@ export default function HeroSection(): ReactNode {
         {/* child 1: hero text section */}
         <section className="hero-text-section">
           <div className="hero-text-inner">
-            <h1 className="hero-h1">The clean stack for{' '}<span className="hero-h1-br" />Artisans and agents.</h1>
+            <h1 className="hero-h1">
+              <Translate id="homepage.hero.title.part1" description="Hero H1 앞부분">Artisan과 에이전트를 위한</Translate>
+              {' '}<span className="hero-h1-br" />
+              <Translate id="homepage.hero.title.part2" description="Hero H1 뒷부분">군더더기 없는 스택.</Translate>
+            </h1>
             <p className="hero-subtitle">
-              Laravel is batteries-included so everyone can{' '}<span className="hero-subtitle-br" />build and ship web apps at ridiculous speed.
+              <Translate id="homepage.hero.subtitle.part1" description="Hero 서브타이틀 앞부분">Laravel은 필요한 것이 모두 갖춰져 있어, 누구나</Translate>
+              {' '}<span className="hero-subtitle-br" />
+              <Translate id="homepage.hero.subtitle.part2" description="Hero 서브타이틀 뒷부분">놀라울 만큼 빠르게 웹 앱을 만들고 출시할 수 있습니다.</Translate>
             </p>
             <div className="hero-buttons">
               <a href="/docs/12.x" className="hero-btn-secondary">
-                View framework docs
+                <Translate id="homepage.hero.cta.viewDocs" description="Hero CTA 버튼">프레임워크 문서 보기</Translate>
               </a>
             </div>
           </div>

--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -5,6 +5,7 @@
 import React, {useEffect, useRef, useState, type ReactNode} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
 
 export default function HeroSection(): ReactNode {
   const [svgContent, setSvgContent] = useState<string>('');
@@ -339,9 +340,9 @@ export default function HeroSection(): ReactNode {
               <Translate id="homepage.hero.subtitle.part2" description="Hero 서브타이틀 뒷부분">놀라울 만큼 빠르게 웹 앱을 만들고 출시할 수 있습니다.</Translate>
             </p>
             <div className="hero-buttons">
-              <a href="/docs/12.x" className="hero-btn-secondary">
+              <Link to="/docs/12.x" className="hero-btn-secondary">
                 <Translate id="homepage.hero.cta.viewDocs" description="Hero CTA 버튼">프레임워크 문서 보기</Translate>
-              </a>
+              </Link>
             </div>
           </div>
         </section>

--- a/src/components/Homepage/NavbarDropdowns.tsx
+++ b/src/components/Homepage/NavbarDropdowns.tsx
@@ -4,6 +4,9 @@ import './homepage.css';
 
 type DropdownName = 'framework' | 'products' | 'resources' | 'events';
 
+// Resources / Events 드롭다운 일시 비활성 플래그. 재활성 시 true 로 변경.
+const SHOW_DISABLED_NAV = false;
+
 const ALL_PARTNERS = [
   { name: 'Steadfast Collective', slug: 'steadfast-collective' },
   { name: 'Tighten', slug: 'tighten' },
@@ -314,7 +317,7 @@ export default function NavbarDropdowns(): ReactNode {
       )}
 
       {/* Resources (일시 비활성화) */}
-      {false && isOpen('resources') && (
+      {SHOW_DISABLED_NAV && isOpen('resources') && (
         <div id="content-resources" data-state={dataState('resources')} className="nav-dropdown-panel" ref={adjustPanelPosition} {...(canHover ? {onMouseEnter: cancelClose, onMouseLeave: scheduleClose} : {})}>
           <div className="nav-dropdown-inner nav-resources-grid">
             {/* Company */}
@@ -413,7 +416,7 @@ export default function NavbarDropdowns(): ReactNode {
       )}
 
       {/* Events (일시 비활성화) */}
-      {false && isOpen('events') && (
+      {SHOW_DISABLED_NAV && isOpen('events') && (
         <div id="content-events" data-state={dataState('events')} className="nav-dropdown-panel" ref={adjustPanelPosition} {...(canHover ? {onMouseEnter: cancelClose, onMouseLeave: scheduleClose} : {})}>
           <div className="nav-dropdown-inner nav-events-grid">
             {/* Upcoming events list */}
@@ -680,7 +683,7 @@ export default function NavbarDropdowns(): ReactNode {
                   <a href="https://nova.laravel.com" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Nova</a>
                 </>}
                 {/* Resources 서브메뉴 일시 비활성화 (메인 메뉴에서 진입 경로 제거됨) */}
-                {false && mobileSubMenu === 'resources' && <>
+                {SHOW_DISABLED_NAV && mobileSubMenu === 'resources' && <>
                   <a href="https://laravel.com/blog" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Blog</a>
                   <a href="https://laravel.com/partners" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Partners</a>
                   <a href="https://laravel.com/careers" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Careers</a>

--- a/src/components/Homepage/NavbarDropdowns.tsx
+++ b/src/components/Homepage/NavbarDropdowns.tsx
@@ -133,7 +133,8 @@ export default function NavbarDropdowns(): ReactNode {
     <div ref={wrapperRef} className="nav-dropdowns-wrapper">
       {/* Dropdown triggers */}
       <div className="nav-dropdown-triggers">
-        {(['framework', 'products', 'resources', 'events'] as DropdownName[]).map(name => (
+        {/* Resources/Events 메뉴 일시 비활성화 */}
+        {(['framework', 'products'] as DropdownName[]).map(name => (
           <button
             key={name}
             id={`trigger-${name}`}
@@ -312,8 +313,8 @@ export default function NavbarDropdowns(): ReactNode {
         </div>
       )}
 
-      {/* Resources */}
-      {isOpen('resources') && (
+      {/* Resources (일시 비활성화) */}
+      {false && isOpen('resources') && (
         <div id="content-resources" data-state={dataState('resources')} className="nav-dropdown-panel" ref={adjustPanelPosition} {...(canHover ? {onMouseEnter: cancelClose, onMouseLeave: scheduleClose} : {})}>
           <div className="nav-dropdown-inner nav-resources-grid">
             {/* Company */}
@@ -411,8 +412,8 @@ export default function NavbarDropdowns(): ReactNode {
         </div>
       )}
 
-      {/* Events */}
-      {isOpen('events') && (
+      {/* Events (일시 비활성화) */}
+      {false && isOpen('events') && (
         <div id="content-events" data-state={dataState('events')} className="nav-dropdown-panel" ref={adjustPanelPosition} {...(canHover ? {onMouseEnter: cancelClose, onMouseLeave: scheduleClose} : {})}>
           <div className="nav-dropdown-inner nav-events-grid">
             {/* Upcoming events list */}
@@ -629,7 +630,8 @@ export default function NavbarDropdowns(): ReactNode {
                 </button>
               </div>
               <nav className="nav-mobile-menu">
-                {(['framework', 'products', 'resources'] as const).map(name => (
+                {/* Resources/Events 일시 비활성화 */}
+                {(['framework', 'products'] as const).map(name => (
                   <button key={name} className="nav-mobile-menu-item" onClick={() => setMobileSubMenu(name)}>
                     <span>{name.charAt(0).toUpperCase() + name.slice(1)}</span>
                     <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#c0c0c0" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" className="nav-mobile-chevron">
@@ -637,9 +639,11 @@ export default function NavbarDropdowns(): ReactNode {
                     </svg>
                   </button>
                 ))}
+                {/*
                 <a href="https://laravel.com/community" className="nav-mobile-menu-item" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>
                   <span>Events</span>
                 </a>
+                */}
                 <a href="/docs/12.x" className="nav-mobile-menu-item" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>
                   <span>Docs</span>
                 </a>
@@ -675,7 +679,8 @@ export default function NavbarDropdowns(): ReactNode {
                   <a href="https://nightwatch.laravel.com" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Nightwatch</a>
                   <a href="https://nova.laravel.com" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Nova</a>
                 </>}
-                {mobileSubMenu === 'resources' && <>
+                {/* Resources 서브메뉴 일시 비활성화 (메인 메뉴에서 진입 경로 제거됨) */}
+                {false && mobileSubMenu === 'resources' && <>
                   <a href="https://laravel.com/blog" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Blog</a>
                   <a href="https://laravel.com/partners" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Partners</a>
                   <a href="https://laravel.com/careers" className="nav-mobile-subitem" onClick={() => { setMobileMenuOpen(false); setMobileSubMenu(null); }}>Careers</a>

--- a/src/components/Homepage/NightwatchSection.tsx
+++ b/src/components/Homepage/NightwatchSection.tsx
@@ -1,5 +1,6 @@
 import React, {type ReactNode} from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Translate, {translate} from '@docusaurus/Translate';
 import {CheckIcon, ArrowIcon, NoiseOverlay} from './SharedIcons';
 
 export default function NightwatchSection(): ReactNode {
@@ -10,28 +11,33 @@ export default function NightwatchSection(): ReactNode {
         <NoiseOverlay className="nightwatch-noise-overlay" />
         <div className="nightwatch-grid">
           <div className="nightwatch-info">
-            <h3>Monitor and fix issues with{' '}<br className="tablet-br" /><br className="mobile-br" />Nightwatch</h3>
+            <h3>
+              <Translate id="homepage.nightwatch.title" description="Nightwatch 섹션 제목">
+                Nightwatch로 이슈를 모니터링하고 해결하세요
+              </Translate>
+            </h3>
             <p>
-              Laravel Nightwatch gives full{' '}<br className="tablet-br" />observability to find errors and top{' '}<br className="tablet-br" />
-              performance{' '}<br className="desktop-only-br" />issues in your apps, before{' '}<br className="tablet-br" />your team does.
+              <Translate id="homepage.nightwatch.desc" description="Nightwatch 섹션 설명">
+                Laravel Nightwatch는 팀이 알아차리기 전에 앱의 오류와 주요 성능 이슈를 찾을 수 있도록 완전한 관찰성을 제공합니다.
+              </Translate>
             </p>
             <ul className="nightwatch-feature-list">
               <li>
                 <CheckIcon className="cloud-check-icon" />
-                <span>Fix errors and performance with{' '}<br className="tablet-br" />recommended solutions</span>
+                <span><Translate id="homepage.nightwatch.feature.fix" description="Nightwatch 기능 1">추천 해결책으로 오류와 성능 문제 수정</Translate></span>
               </li>
               <li>
                 <CheckIcon className="cloud-check-icon" />
-                <span>Trace requests, jobs, logs,{' '}<br className="tablet-br" />commands, cache, and more</span>
+                <span><Translate id="homepage.nightwatch.feature.trace" description="Nightwatch 기능 2">요청, 작업, 로그, 명령어, 캐시 등 추적</Translate></span>
               </li>
               <li>
                 <CheckIcon className="cloud-check-icon" />
-                <span>Let agents fix your code using{' '}<br className="tablet-br" />Nightwatch MCP</span>
+                <span><Translate id="homepage.nightwatch.feature.mcp" description="Nightwatch 기능 3">Nightwatch MCP로 에이전트가 직접 코드 수정</Translate></span>
               </li>
             </ul>
             <div className="nightwatch-btn-wrapper">
               <a href="https://nightwatch.laravel.com" className="explore-btn">
-                Explore Nightwatch
+                <Translate id="homepage.nightwatch.cta" description="Nightwatch CTA 링크">Nightwatch 살펴보기</Translate>
                 <ArrowIcon />
               </a>
             </div>
@@ -41,7 +47,7 @@ export default function NightwatchSection(): ReactNode {
             <div className="nightwatch-img-wrapper">
               <img
                 src={dashboardUrl}
-                alt="Nightwatch dashboard screenshot"
+                alt={translate({id: 'homepage.nightwatch.img.alt', message: 'Nightwatch 대시보드 스크린샷', description: 'Nightwatch 대시보드 이미지 alt'})}
                 className="nightwatch-img"
                 loading="lazy"
               />


### PR DESCRIPTION
## Summary
- Homepage(Hero/Framework/Cloud/Nightwatch/Frontend/Events/CTA) 섹션의 영문 하드코딩을 `@docusaurus/Translate` 로 래핑하고 한국어 카피를 제공
- 브랜드 고유명사(Laravel/Artisan/Boost/Inertia/Livewire/Cloud/Nightwatch/MCP)는 원문 유지, Ship(출시)과 Deploy(배포) 의미 중복을 분리
- 현재 사용하지 않는 Navbar `Resources/Events` 드롭다운과 Events 카드 캐러셀을 주석 가드(`{false && ...}`)로 일시 비활성화, 남은 dead code 정리
- 다크모드 진입 시 Hero SVG fetch 구간에 밝은 PNG 폴백이 번쩍이던 문제를 `svgStatus` 상태로 해결, 회귀 방지 E2E 테스트 추가
- `HeroSection` 상단에 `npx docusaurus write-translations --locale ko` 로 `i18n/ko/code.json` 을 추출하는 방법을 주석으로 안내

## Commits
- `b2809fe` feat: 홈페이지 섹션에 i18n 적용 및 한국어 카피 반영
- `702c980` refactor: Events/Navbar 비활성 영역 정리
- `2cad3e2` fix: 다크모드에서 Hero SVG 로딩 중 밝은 PNG 폴백 깜빡임 제거
- `740f397` docs: i18n/ko/code.json 추출 방법 안내 주석 추가