### PR TITLE
fix(translation): recognize HTML code identifier lists

### DIFF
--- a/translation-sync/docs/02-translation.md
+++ b/translation-sync/docs/02-translation.md
@@ -108,7 +108,7 @@ PatchPlan과 블록 집합은 [후처리 단계](./03-postprocessing.md)로 함�
 1. 일반 prose는 `<!-- {canonical current English source text} -->` 다음에 목표 언어 번역문 배치; 중괄호 부분은 literal이 아닌 해당 source text로 치환.
 2. heading은 `<!-- # {current English heading text} -->` 다음에 현재 영어 원문과 같은 Markdown heading 배치; 중괄호 부분은 실제 heading text로 치환; heading 본문은 번역하지 않고 annotation은 source/target 상태 판정을 위한 서명으로 유지.
 3. blockquote 본문에는 새 annotation 추가 금지; 기존 exact quoted-source annotation은 호환용으로 허용.
-4. 순수 inline-code 식별자 목록 항목은 annotation 대상 아님.
+4. Markdown inline code 또는 raw HTML `<code>`로만 구성된 식별자 목록 항목은 annotation 대상 아님.
 5. 표로만 구성된 요청(행 수정·표 create)의 provider 응답 annotation은 선택 표현: 부착하면 response contract와 PatchPlan 적용 위치 판정에만 사용하고, 생략해도 계약 위반이 아님; 전체 문서 후처리가 현재 표 전체 원문을 담은 canonical annotation 하나로 항상 재생성; 최종 문서에서는 해당 annotation을 표 첫 행 바로 앞에 배치하고 표 행 사이의 HTML 주석 금지; 표 create 응답은 표 전체를 하나의 owner로 사용.
 6. source에 없는 standalone 구조 주석을 provider가 추가하면 거부.
 
@@ -198,7 +198,7 @@ unguarded plan은 exact old/new 구조가 같은 문서 상태와 일치할 때�
 | 독립 fenced-code-only 변경 | 불필요 | 원문 전체 code block을 그대로 교체 |
 | bare 내부 링크 목록 | 불필요 | 원문 구조 블록을 그대로 반영 |
 | 사이드바 구조 목록 (링크 label·카테고리 heading 항목만) | 불필요 | 링크 label과 카테고리 label은 영어 유지 대상이므로 원문 구조 블록을 그대로 반영 |
-| inline-code 식별자 목록 | 불필요 | 원문 구조 블록을 그대로 반영 |
+| code 식별자 목록 (Markdown inline code·raw HTML `<code>`) | 불필요 | 원문 구조 블록을 그대로 반영 |
 | 표 (지원 조건 내) | 필요 | provider 응답 범위는 수정 시 변경 전후 각 한 행·동일 열 수인 기존 행, create 시 직사각형 전체 표. 최종 문서 owner는 두 경우 모두 현재 표 전체 |
 | admonition 본문 | 필요 | marker는 구조 context로 유지, 연속 변경 본문 segment |
 | admonition marker 유형 변경 | 필요 | marker + 연속 quote 본문 전체 |

--- a/translation-sync/sync/translation/patch.py
+++ b/translation-sync/sync/translation/patch.py
@@ -2393,6 +2393,8 @@ def _is_plan_anchor(block: AnnotatedBlock) -> bool:
 def _is_inline_code_identifier_list_comment(comment: str) -> bool:
     """code identifier list comment 여부."""
 
+    if not _LIST_ITEM_PREFIX_RE.match(comment):
+        return False
     if not (inline_code_contents(comment) or html_code_contents(comment)):
         return False
     remainder = strip_html_code_elements(strip_inline_code(comment))

--- a/translation-sync/sync/translation/patch.py
+++ b/translation-sync/sync/translation/patch.py
@@ -18,6 +18,7 @@ from ..common.markdown import (
     front_matter_description,
     gfm_table_row_cells,
     has_malformed_html_comment_delimiters,
+    html_code_contents,
     html_comment_spans,
     html_tags,
     inline_code_contents,
@@ -31,6 +32,7 @@ from ..common.markdown import (
     normalize_annotation_anchor,
     reference_definition_line_numbers,
     standalone_html_comment_line_numbers,
+    strip_html_code_elements,
     strip_inline_code,
     strip_title_attr_line,
 )
@@ -2389,11 +2391,11 @@ def _is_plan_anchor(block: AnnotatedBlock) -> bool:
 
 
 def _is_inline_code_identifier_list_comment(comment: str) -> bool:
-    """inline code identifier list comment 여부."""
+    """code identifier list comment 여부."""
 
-    if not inline_code_contents(comment):
+    if not (inline_code_contents(comment) or html_code_contents(comment)):
         return False
-    remainder = strip_inline_code(comment)
+    remainder = strip_html_code_elements(strip_inline_code(comment))
     remainder = re.sub(r"(?:[-*+]|\d+[.)])", " ", remainder)
     return not remainder.strip(" `*_~.,:;()[]&/,+")
 
@@ -6114,7 +6116,7 @@ def _plan_source_blocks(blocks: list[SourceBlock]) -> list[SourceBlock]:
 
 
 def _is_inline_code_identifier_list(text: str) -> bool:
-    """inline code identifier list 여부."""
+    """code identifier list 여부."""
 
     lines = [line for line in text.splitlines() if line.strip()]
     if not lines:
@@ -6124,7 +6126,9 @@ def _is_inline_code_identifier_list(text: str) -> bool:
         if list_item is None:
             return False
         body = line[list_item.end() :]
-        if not inline_code_contents(body) or strip_inline_code(body).strip(
+        if not (inline_code_contents(body) or html_code_contents(body)):
+            return False
+        if strip_html_code_elements(strip_inline_code(body)).strip(
             " `*_~.,:;()[]&/,+"
         ):
             return False

--- a/translation-sync/sync/verification/response_contract.py
+++ b/translation-sync/sync/verification/response_contract.py
@@ -2141,11 +2141,11 @@ def _distinctive_technical_term(token: str) -> bool:
 
 
 def _is_inline_code_only_list_item(body: str) -> bool:
-    """목록 항목이 inline code 식별자만 포함하는지 여부."""
+    """목록 항목이 code 식별자만 포함하는지 여부."""
 
-    if not inline_code_contents(body):
+    if not (inline_code_contents(body) or html_code_contents(body)):
         return False
-    remainder = strip_inline_code(body)
+    remainder = strip_html_code_elements(strip_inline_code(body))
     return not remainder.strip(_PROSE_TRIM_CHARACTERS)
 
 

--- a/translation-sync/tests/translation/test_patch.py
+++ b/translation-sync/tests/translation/test_patch.py
@@ -2759,12 +2759,13 @@ Paragraph.
         self.assertEqual(len(blocks), 1)
         self.assertEqual(blocks[0].comment, "First line. Second line.")
 
-    def test_updates_unannotated_inline_code_identifier_list(self):
-        """주석 없는 인라인 코드 식별자 목록을 갱신함."""
+    def test_updates_mixed_code_identifier_list(self):
+        """Markdown과 HTML code 식별자 목록을 provider 없이 갱신함."""
 
         old = (
             "Before.\n\n"
             "- `FirstEvent`\n"
+            "- <code>decimal:&lt;precision&gt;</code>\n"
             "- `LastEvent`\n\n"
             "After.\n"
         )
@@ -2776,20 +2777,32 @@ Paragraph.
             "<!-- Before. -->\n이전입니다.\n\n"
             "<!--\n"
             "- `FirstEvent`\n"
+            "- <code>decimal:&lt;precision&gt;</code>\n"
             "- `LastEvent`\n"
             "-->\n"
             "- `FirstEvent`\n"
+            "- <code>decimal:&lt;precision&gt;</code>\n"
             "- `LastEvent`\n\n"
             "<!-- After. -->\n이후입니다.\n"
         )
-
-        result = patch.apply_plan(
-            existing,
-            _plan(old, new),
-            ["- `FirstEvent`\n- `AddedEvent`\n- `LastEvent`"],
+        plan = _plan(old, new)
+        translated = (
+            "- `FirstEvent`\n"
+            "- <code>decimal:&lt;precision&gt;</code>\n"
+            "- `AddedEvent`\n"
+            "- `LastEvent`"
         )
 
-        self.assertIn("- `FirstEvent`\n- `AddedEvent`\n- `LastEvent`", result)
+        self.assertTrue(plan.changes[0].provider_free)
+        self.assertFalse(
+            patch._is_plan_anchor_comment(  # noqa: SLF001
+                " ".join(translated.splitlines())
+            )
+        )
+
+        result = patch.apply_plan(existing, plan, [translated])
+
+        self.assertIn(translated, result)
         self.assertNotIn("<!--\n- `FirstEvent`", result)
 
 

--- a/translation-sync/tests/translation/test_patch.py
+++ b/translation-sync/tests/translation/test_patch.py
@@ -2793,7 +2793,7 @@ Paragraph.
             "- `LastEvent`"
         )
 
-        self.assertTrue(plan.changes[0].provider_free)
+        self.assertEqual([change.provider_free for change in plan.changes], [True])
         self.assertFalse(
             patch._is_plan_anchor_comment(  # noqa: SLF001
                 " ".join(translated.splitlines())
@@ -2804,6 +2804,18 @@ Paragraph.
 
         self.assertIn(translated, result)
         self.assertNotIn("<!--\n- `FirstEvent`", result)
+
+    def test_updates_standalone_html_code_paragraph(self):
+        """단독 HTML code 문단을 목록으로 오인하지 않고 갱신함."""
+
+        old = "<code>Old</code>\n"
+        new = "<code>New</code>\n"
+        existing = "<!-- <code>Old</code> -->\n<code>Old</code>\n"
+        translated = "<!-- <code>New</code> -->\n<code>New</code>"
+
+        result = patch.apply_plan(existing, _plan(old, new), [translated])
+
+        self.assertEqual(result, f"{translated}\n")
 
 
 class TableRowPatchTests(unittest.TestCase):

--- a/translation-sync/tests/verification/test_response_contract.py
+++ b/translation-sync/tests/verification/test_response_contract.py
@@ -699,10 +699,16 @@ Acquire the cache lock.
             [],
         )
 
-    def test_accepts_unannotated_inline_code_only_identifier_list(self):
-        """annotation이 없는 inline code 식별자 목록을 허용."""
+    def test_accepts_unannotated_mixed_code_identifier_list(self):
+        """annotation이 없는 Markdown·HTML code 식별자 목록을 허용."""
 
-        source = "- `data`\n- `render`\n- `resolve`\n- `shouldRender`\n"
+        source = (
+            "- `data`\n"
+            "- <code>decimal:&lt;precision&gt;</code>\n"
+            "- `render`\n"
+            "- `resolve`\n"
+            "- `shouldRender`\n"
+        )
 
         self.assertEqual(
             response_contract.verify(source, source, locale="ko"),


### PR DESCRIPTION
## 요약

- [예약 번역 동기화 작업에서 발생한 오류](https://github.com/letsescape/laravel-docs/actions/runs/33124211708/job/98698298381)를 해결합니다.
- Markdown inline code와 raw HTML `<code>`가 혼합된 식별자 목록을 provider 호출 없이 처리하도록 patch 계획, legacy annotation, provider 응답 검증 규칙을 정렬합니다.
- 혼합 code 식별자 목록 회귀 테스트와 관련 번역 계약 문서를 갱신합니다.

## 원인

Laravel upstream에서 `<code>decimal:&lt;precision&gt;</code>` 항목을 포함한 cast 목록에 `AsVector::class`가 추가됐습니다. 기존 분류기가 Markdown inline code만 인식해 해당 목록을 번역 대상으로 잘못 분류했고, 전체 재번역 경로에서 `provider annotation ownership mismatch`가 발생했습니다.

## 변경 사항

- PatchPlan의 source 목록 및 legacy annotation 분류에서 raw HTML `<code>` 요소를 인식합니다.
- provider response contract에서 동일한 목록을 annotation 불필요 대상으로 처리합니다.
- 기존 테스트와 문서에 혼합 식별자 목록 계약을 반영합니다.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes translation sync misclassifying code identifier lists that mix Markdown inline code and raw HTML `<code>` elements, which caused `provider annotation ownership mismatch` errors during re-translation. Code comments must now use list syntax to count as identifier lists, so standalone HTML `<code>` paragraphs are no longer misclassified.

- Patch plan, legacy annotation classification, and provider response validation now treat raw HTML `<code>` elements as code identifiers.
- Mixed code identifier lists are handled without provider calls, matching existing inline-code-only behavior.
- Added regression tests for mixed lists and standalone HTML code paragraphs, and updated translation contract docs.

<sup>Written for commit 477c53f94fdd65bfb76afd9f27d92a1dceb5bf7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/letsescape/laravel-docs/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

